### PR TITLE
Move fstab to devices

### DIFF
--- a/aosp_d2303.mk
+++ b/aosp_d2303.mk
@@ -28,6 +28,7 @@ PRODUCT_COPY_FILES += \
     device/sony/eagle/rootdir/system/etc/thermanager.xml:system/etc/thermanager.xml \
     device/sony/eagle/rootdir/system/etc/sap.conf:system/etc/sap.conf \
     device/sony/eagle/rootdir/system/etc/sec_config:system/etc/sec_config \
+    device/sony/eagle/rootdir/fstab.yukon:root/fstab.yukon \
     device/sony/eagle/rootdir/init.yukon.dev.rc:root/init.yukon.dev.rc
 
 # Product attributes

--- a/rootdir/fstab.yukon
+++ b/rootdir/fstab.yukon
@@ -1,0 +1,15 @@
+# Android fstab file.
+# The filesystem that contains the filesystem checker binary (typically /system) cannot
+# specify MF_CHECK, and must come before any filesystems that do specify MF_CHECK
+
+#TODO: Add 'check' as fs_mgr_flags with data partition.
+# Currently we dont have e2fsck compiled. So fs check would failed.
+
+#<src>                                                <mnt_point>         <type>  <mnt_flags and options>                                       <fs_mgr_flags>
+/dev/block/platform/msm_sdcc.1/by-name/system         /system              ext4    ro,barrier=1                                                     wait
+/dev/block/platform/msm_sdcc.1/by-name/cache          /cache               ext4    noatime,nosuid,nodev,barrier=1,data=ordered                      wait,check
+/dev/block/platform/msm_sdcc.1/by-name/userdata       /data                ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc      wait,check,encryptable=footer
+/dev/block/platform/msm_sdcc.1/by-name/modem          /firmware            vfat    ro,shortname=lower,uid=1000,gid=1000,dmask=227,fmask=337         wait
+
+/devices/msm_sdcc.2/mmc_host                          /storage/sdcard1     vfat    noatime,nosuid,nodev                                             wait,voldmanaged=sdcard1:auto
+/devices/platform/msm_hsusb_host/usb1/1-1/            /storage/usbdisk     vfat    noatime,nosuid,nodev                                             wait,voldmanaged=usbdisk:auto


### PR DESCRIPTION
If /firmware partition does not exist then internal storage will not mount

Signed-off-by: Adam Farden adam@farden.cz
