### PR TITLE
eagle: use specific idProduct for usb paths

### DIFF
--- a/aosp_d2303.mk
+++ b/aosp_d2303.mk
@@ -46,4 +46,5 @@ PRODUCT_AAPT_PREBUILT_DPI := hdpi
 PRODUCT_AAPT_PREF_CONFIG := hdpi
 
 PRODUCT_PROPERTY_OVERRIDES += \
-    ro.sf.lcd_density=240
+    ro.sf.lcd_density=240 \
+    ro.usb.pid_suffix=1B8


### PR DESCRIPTION
from 18.3.1.C.1.13

Signed-off-by: David Viteri <davidteri91@gmail.com>