### PR TITLE
eagle: Update NFC NXP HAL naming

### DIFF
--- a/aosp_d2303.mk
+++ b/aosp_d2303.mk
@@ -35,6 +35,10 @@ PRODUCT_COPY_FILES += \
     device/sony/eagle/rootdir/fstab.yukon:root/fstab.yukon \
     device/sony/eagle/rootdir/init.yukon.dev.rc:root/init.yukon.dev.rc
 
+# NFC config
+PRODUCT_PACKAGES += nfc_nci.eagle
+ADDITIONAL_DEFAULT_PROPERTIES += ro.hardware.nfc_nci=eagle
+
 # Product attributes
 PRODUCT_NAME := aosp_d2303
 PRODUCT_DEVICE := eagle


### PR DESCRIPTION
This patch just uses AOSP directives by updating NFC HAL name
using the device name and declares the additional property "ro.hardware.nfc_nci"
to default.prop. So it fixes hw_get_module process.

AOSP uses $(TARGET_DEVICE) as NFC HAL composition naming
as commented here:

https://android-review.googlesource.com/#/c/155054/

By: Thierry Strudel

TARGET_BOARD_PLATFORM is set to the SoC name of a product
and the NFC chip has no relation to it.
TARGET_DEVICE is the only variable fully defining the device
and so selecting an HW device appropriately.
Given it should be easy to update PRODUCT_PACKAGES of any legacy device

Signed-off-by: Humberto Borba <humberos@gmail.com>