### PR TITLE
NFC: Add back lost symlink

### DIFF
--- a/rootdir/init.eagle.rc
+++ b/rootdir/init.eagle.rc
@@ -21,6 +21,7 @@ on init
 
 on post-fs-data
     # Symlink for compability
+    symlink /dev/pn54x /dev/pn544
     symlink /dev/pn54x /dev/pn547
 
 on fs


### PR DESCRIPTION
HAL is hardwired to look at pn544

Signed-off-by: Adam Farden <adam@farden.cz>