### PR TITLE
eagle: init: Remove unneeded symlink

### DIFF
--- a/rootdir/init.eagle.rc
+++ b/rootdir/init.eagle.rc
@@ -16,9 +16,6 @@ import init.common.rc
 import init.common.usb.rc
 import init.yukon.pwr.rc
 
-on init
-    symlink /dev/block/platform/msm_sdcc.1 /dev/block/bootdevice
-
 on post-fs-data
     # Symlink for compability
     symlink /dev/pn54x /dev/pn547


### PR DESCRIPTION
This symlink will be created by bootloader
through cmdline parameter:

androidboot.bootdevice=msm_sdcc.1

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: Ia08f5f19492a06011093feb81cd6a44f1a516562